### PR TITLE
Bump cookiecutter template to 1306a6

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "25c36c49159f9309b55815b6606a8dfb66228858",
+  "commit": "1306a62cc620405d621b40b8dc54a7bdca91e634",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.15.0
-pdm==2.15.2
+pdm==2.15.3
 pre-commit==3.7.1
 wheel==0.43.0


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/1306a6
