### PR TITLE
Bump cookiecutter template to 6c948a

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "cf7f28ed2a2abbeb6b7eb2319e5c894d7020d675",
+  "commit": "20d79c1e1bde360a5767847f79ad70b683a5d88f",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -2,6 +2,8 @@ name: CVE Scan
 
 on:
   push:
+    branches: ["main"]
+    tags: ["**"]
   pull_request:
     types:
       - opened

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,6 +2,8 @@ name: Linting
 
 on:
   push:
+    branches: ["main"]
+    tags: ["**"]
   pull_request:
     types:
       - opened

--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v40.2.4
+        uses: renovatebot/github-action@v40.2.5
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-release"

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *.cover
+*.jpeg
 *.py,cover
 .hypothesis/
 .pytest_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ distribution = true
 
 [tool.pdm.scripts]
 update-all = { cmd = "pdm update --group :all --update-all --save-compatible" }
-lock-all = { cmd = "pdm lock --group :all --refresh" }
+lock-all = { cmd = "pdm lock --group :all --python='==3.11.*'" }
 install-all = { cmd = "pdm install --group :all --frozen-lockfile" }
 export-all = { cmd = "pdm export --group :all --no-hashes -f requirements" }
 apidoc = { cmd = "pdm run sphinx-apidoc -f -o docs/source mex" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cruft==2.15.0
 mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
-pdm==2.17.2
+pdm==2.17.3
 pre-commit==3.8.0
-wheel==0.43.0
+wheel==0.44.0


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/6c948a

# Conflicts

```diff a/pyproject.toml b/pyproject.toml	(rejected hunks)
@@ -16,7 +16,7 @@ optional-dependencies.dev = [
     "pytest-xdist==3.6.1",
     "pytest==8.3.1",
     "ruff==0.5.4",
-    "sphinx==7.4.0",
+    "sphinx==7.4.5",
 ]
 
 [project.scripts]
```

```diff a/.github/workflows/release.yml b/.github/workflows/release.yml	(rejected hunks)
@@ -88,7 +88,7 @@ jobs:
     needs: release
     steps:
       - name: Build, tag and push docker image to ghcr
-        uses: GlueOps/github-actions-build-push-containers@v0.4.3
+        uses: GlueOps/github-actions-build-push-containers@v0.4.4
         with:
           tags: "${{ github.sha }},${{ needs.release.outputs.tag }},latest"
 
```

```diff a/.github/workflows/renovatebot.yml b/.github/workflows/renovatebot.yml	(rejected hunks)
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v40.2.2
+        uses: renovatebot/github-action@v40.2.4
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-release"
```

```diff a/requirements.txt b/requirements.txt	(rejected hunks)
@@ -1,5 +1,5 @@
 cruft==2.15.0
 mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
-pdm==2.17.1
-pre-commit==3.7.1
+pdm==2.17.3
+pre-commit==3.8.0
 wheel==0.43.0
```
