### PR TITLE
Bump cookiecutter template to bae864

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "cee205846b2eb6f25e1ce762f395aa50ccbbf93e",
+  "commit": "bae86448088992cdbd3acde751ad7aa19a79d71b",
   "checkout": null,
   "context": {
     "cookiecutter": {


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/bae864

# Conflicts

```diff a/.github/workflows/release.yml b/.github/workflows/release.yml	(rejected hunks)
@@ -127,7 +127,7 @@ jobs:
           --tag ghcr.io/robert-koch-institut/mex-release:latest \
           --tag ghcr.io/robert-koch-institut/mex-release:${{ github.sha }} \
           --tag ghcr.io/robert-koch-institut/mex-release:${{ needs.release.outputs.tag }}
-          docker push ghcr.io/robert-koch-institut/mex-release:latest
+          docker push --all-tags ghcr.io/robert-koch-institut/mex-release
 
   distribute:
     runs-on: ubuntu-latest
```
