### PR TITLE
Bump cookiecutter template to 71224c

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "5446dae8486bd2412e75f97790c6bd800fa26a34",
+  "commit": "71224cdf6b9828906fd1591f7572bdb12f8f9408",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Create new release with `pdm release VERSION`",
       "long_summary": "Create a new release, including changelog rollover, project version bump, commit, tag and push.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "5446dae8486bd2412e75f97790c6bd800fa26a34"
+      "_commit": "71224cdf6b9828906fd1591f7572bdb12f8f9408"
     }
   },
   "directory": null

--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,11 @@ dmypy.json
 # SQLite databases
 *.db
 
+# Reflex
+.states
+assets/external/
+.web
+
 # Default exports
 *.ndjson
 data/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
   python: python3.11
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.9.6
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -25,7 +25,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/pdm-project/pdm
-    rev: 2.22.2
+    rev: 2.22.3
     hooks:
       - id: pdm-lock-check
         name: pdm


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/71224c
