### PR TITLE
Bump cookiecutter template to 716a58

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "8bdad06a5eca52607f046b75cb0cdd9d7ab4912e",
+  "commit": "716a581e36bd544e0b34a7f92078435de557fa76",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Create new release with `pdm release VERSION`",
       "long_summary": "Create a new release, including changelog rollover, project version bump, commit, tag and push.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "8bdad06a5eca52607f046b75cb0cdd9d7ab4912e"
+      "_commit": "716a581e36bd544e0b34a7f92078435de557fa76"
     }
   },
   "directory": null

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ downloads/
 eggs/
 lib/
 lib64/
+locked-requirements.txt
 MANIFEST
 parts/
 sdist/
@@ -49,7 +50,7 @@ coverage.xml
 test*.jpeg
 test*.png
 *.cover
-*.py,cover
+*,cover
 .hypothesis/
 .pytest_cache/
 cover/
@@ -84,7 +85,7 @@ ipython_config.py
 __pypackages__/
 
 # Celery stuff
-celerybeat-schedule
+celerybeat-schedule.*
 celerybeat.pid
 
 # Environments
@@ -126,10 +127,14 @@ dmypy.json
 assets/external/
 .web
 
-# Default exports
+# MEx specific
+.aws/
+.invenio.private
 *.ndjson
 data/
 identity.csv
+logs/
+payload
 schema.json
 tmp*/
 work/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
   python: python3.11
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.6
+    rev: v0.9.10
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -25,7 +25,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/pdm-project/pdm
-    rev: 2.22.3
+    rev: 2.22.4
     hooks:
       - id: pdm-lock-check
         name: pdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
-pdm==2.22.3
+pdm==2.22.4
 pre-commit==4.1.0


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/716a58

# Conflicts

```diff a/pyproject.toml b/pyproject.toml	(rejected hunks)
@@ -11,7 +11,7 @@ dependencies = []
 optional-dependencies.dev = [
     "ipdb>=0.13,<1",
     "mypy>=1,<2",
-    "pytest-cov>=5,<6",
+    "pytest-cov>=6,<7",
     "pytest-random-order>=1,<2",
     "pytest-xdist>=3,<4",
     "pytest>=8,<9",
```

```diff a/requirements.txt b/requirements.txt	(rejected hunks)
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release==0.3.0
-pdm==2.22.3
+pdm==2.22.4
 pre-commit==4.1.0
```

```diff a/.github/workflows/renovatebot.yml b/.github/workflows/renovatebot.yml	(rejected hunks)
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v41.0.13
+        uses: renovatebot/github-action@v41.0.14
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-release"
```

```diff a/.github/workflows/release.yml b/.github/workflows/release.yml	(rejected hunks)
@@ -86,6 +86,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          ref: ${{ needs.release.outputs.tag }}
 
       - name: Cache requirements
         uses: actions/cache@v4
```
