### PR TITLE
Bump cookiecutter template to 7de6ba

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "ed5deb106b3d34aa758dcd4f4d3628a1ffb2b159",
+  "commit": "7de6bafd6cadfebd1fdaff228960adc884bb48b5",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Create new release with `pdm release VERSION`",
       "long_summary": "Create a new release, including changelog rollover, project version bump, commit, tag and push.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "ed5deb106b3d34aa758dcd4f4d3628a1ffb2b159"
+      "_commit": "7de6bafd6cadfebd1fdaff228960adc884bb48b5"
     }
   },
   "directory": null


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/7de6ba
