### PR TITLE
Bump cookiecutter template to 0d8c47

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "26afa85ef969fa8385019c932f32d6b7b452b142",
+  "commit": "0d8c4782a38f66faeaa24cc853c191cc624a9dff",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Release tools for the RKI MEx project.",
       "long_summary": "Create a new release, including changelog rollover, project version bump, commit, tag and push.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "26afa85ef969fa8385019c932f32d6b7b452b142"
+      "_commit": "0d8c4782a38f66faeaa24cc853c191cc624a9dff"
     }
   },
   "directory": null

--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -65,24 +65,25 @@ jobs:
       - name: Update template and commit
         id: update
         run: |
-          if cruft check; then
+          template_url=$(python -c "print(__import__('json').load(open('.cruft.json'))['template'])")
+          template_tag=$(git ls-remote --tags --sort=-v:refname "${template_url}" | grep -v '\^{}' | head -1 | sed 's|.*refs/tags/||')
+          if cruft check --checkout "${template_tag}"; then
             echo template is up to date
             exit 0
           fi
-          if [[ $(gh pr list --label cruft | wc -c) -ne 0 ]]; then
+          if [[ -n "$(gh pr list --label cruft --state open --json number --jq '.[].number')" ]]; then
             echo already seeing pull request
             exit 0
           fi
-          template_url=$(python -c "print(__import__('json').load(open('.cruft.json'))['template'])")
-          template_ref=$(git ls-remote ${template_url} --heads main --exit-code | cut -c -6)
-          echo "template_ref=${template_ref}" >> "$GITHUB_OUTPUT"
+          echo "template_tag=${template_tag}" >> "$GITHUB_OUTPUT"
           git checkout main
-          git checkout -b cruft/cookiecutter-template-${template_ref}
-          cruft update --skip-apply-ask
-          printf '### Changes\n\n- bumped cookiecutter template to %s/commit/%s\n' "$template_url" "$template_ref" > .cruft-pr-body
-          sed -i "0,/^### Changes/s|^### Changes.*|&\n\n- updated template to ${template_url}/commit/${template_ref}|" CHANGELOG.md
+          git checkout -b cruft/mex-template-${template_tag}
+          cruft update --checkout "${template_tag}" --skip-apply-ask
+          printf '### Changes\n\n- new template %s/releases/tag/%s\n' "$template_url" "$template_tag" > .cruft-pr-body
+          sed -i "0,/^### Changes$/{/^### Changes$/{N;s|\n|\n\n- new template ${template_url}/releases/tag/${template_tag}|}}" CHANGELOG.md
           if [[ $(find . -type f -name "*.rej" | wc -l) -ne 0 ]]; then
             printf '\n### Conflicts\n' >> .cruft-pr-body
+            echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           fi
           find . -type f -name "*.rej" | while read -r line ; do
             printf '\n```diff\n' >> .cruft-pr-body
@@ -90,25 +91,31 @@ jobs:
             printf '```\n' >> .cruft-pr-body
           done
           git add --all --verbose
-          git commit --message "Bump cookiecutter template to $template_ref" --verbose
+          git commit --message "Update mex-template to $template_tag" --verbose
 
       - name: Push branch
-        if: steps.update.outputs.template_ref
+        if: steps.update.outputs.template_tag
         env:
           GH_TOKEN: ${{ secrets.MEX_COOKIECUTTER_TOKEN }}
-          template_ref: ${{ steps.update.outputs.template_ref }}
+          template_tag: ${{ steps.update.outputs.template_tag }}
         run: |
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push --set-upstream origin cruft/cookiecutter-template-${template_ref} --force --verbose
+          git push --set-upstream origin cruft/mex-template-${template_tag} --force --verbose
 
       - name: Create pull request
-        if: steps.update.outputs.template_ref
+        if: steps.update.outputs.template_tag
         env:
           GH_TOKEN: ${{ secrets.MEX_COOKIECUTTER_TOKEN }}
-          template_ref: ${{ steps.update.outputs.template_ref }}
+          template_tag: ${{ steps.update.outputs.template_tag }}
+          has_conflicts: ${{ steps.update.outputs.has_conflicts }}
         run: |
+          draft_flag=""
+          if [[ "${has_conflicts}" == "true" ]]; then
+            draft_flag="--draft"
+          fi
           gh pr create \
-          --title "Bump cookiecutter template to ${template_ref}" \
+          --title "Bump cookiecutter template to ${template_tag}" \
           --body-file .cruft-pr-body \
           --label cruft \
-          --assignee ${MEX_BOT_USER}
+          --assignee ${MEX_BOT_USER} \
+          ${draft_flag}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 fail_fast: false
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.15.16
     hooks:
       - id: ruff-check
         name: ruff-check
@@ -9,7 +9,7 @@ repos:
       - id: ruff-format
         name: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: pretty-format-json
         name: json
@@ -25,7 +25,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.8
+    rev: 0.11.20
     hooks:
       - id: uv-lock
         name: uv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/0d8c47
+
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/26afa8
 
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/57105a

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
     "lockFileMaintenance": {
         "enabled": true,
         "schedule": [
-            "before 4am on monday"
+            "on monday"
         ]
     },
     "packageRules": [
@@ -38,7 +38,30 @@
             "pinDigests": true
         },
         {
-            "description": "Immediately apply updates of mex packages",
+            "description": "Group all GitHub Actions updates into a single PR",
+            "groupName": "github-actions",
+            "matchManagers": [
+                "github-actions"
+            ]
+        },
+        {
+            "description": "Group all non-major Python updates into a single PR",
+            "groupName": "python non-major",
+            "matchCurrentVersion": "!/^0/",
+            "matchManagers": [
+                "pep621",
+                "pip_requirements"
+            ],
+            "matchUpdateTypes": [
+                "minor",
+                "patch",
+                "pin",
+                "digest"
+            ]
+        },
+        {
+            "description": "Immediately apply updates of mex packages in dedicated PR",
+            "groupName": null,
             "matchPackageNames": [
                 "mex-*"
             ],
@@ -46,6 +69,9 @@
         }
     ],
     "prFooter": "",
+    "pre-commit": {
+        "enabled": true
+    },
     "vulnerabilityAlerts": {
         "enabled": true
     }


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/0d8c47

### Conflicts

```diff
diff a/README.md b/README.md	(rejected hunks)
@@ -94,7 +94,7 @@ components of the MEx project are open-sourced under the same license as well.
 Images released to GHCR are signed using [cosign](https://github.com/sigstore/cosign).
 
 To verify an image manually:
-`cosign verify --certificate-identity-regexp "https://github.com/robert-koch-institut/release" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ghcr.io/robert-koch-institut/release:<tag>`
+`cosign verify --certificate-identity-regexp "https://github.com/robert-koch-institut/mex-release/.github/workflows/release.yml@refs/heads/main" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ghcr.io/robert-koch-institut/mex-release:<tag>`
 
 ## Commands
 
```

```diff
diff a/.github/workflows/release.yml b/.github/workflows/release.yml	(rejected hunks)
@@ -111,9 +111,9 @@ jobs:
         with:
           push: true
           tags: |
-            ${IMAGE}:latest
-            ${IMAGE}:${{ github.sha }}
-            ${IMAGE}:${TAG}
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+            ${{ env.IMAGE }}:${{ env.TAG }}
           outputs: type=image,oci-mediatypes=true
 
       - name: Install cosign
```
