### PR TITLE
Bump cookiecutter template to 1.2.0

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,14 +1,14 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "f970f135d97da17b564067eeb9630a691d094b6b",
-  "checkout": null,
+  "commit": "48ce427bbd5a3ff53c603e6cea58c74de439ecc5",
+  "checkout": "1.2.0",
   "context": {
     "cookiecutter": {
       "project_name": "release",
       "short_summary": "Release tools for the RKI MEx project.",
       "long_summary": "Create a new release, including changelog rollover, project version bump, commit, tag and push.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "f970f135d97da17b564067eeb9630a691d094b6b"
+      "_commit": "48ce427bbd5a3ff53c603e6cea58c74de439ecc5"
     }
   },
   "directory": null

--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Setup python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.14
 
@@ -64,28 +64,25 @@ jobs:
 
       - name: Update template and commit
         id: update
-        env:
-          GH_TOKEN: ${{ secrets.MEX_COOKIECUTTER_TOKEN }}
         run: |
-          template_url=$(python -c "print(__import__('json').load(open('.cruft.json'))['template'])")
-          template_tag=$(git ls-remote --tags --sort=-v:refname "${template_url}" | grep -v '\^{}' | head -1 | sed 's|.*refs/tags/||')
-          if cruft check --checkout "${template_tag}"; then
+          if cruft check; then
             echo template is up to date
             exit 0
           fi
-          if [[ -n "$(gh pr list --label cruft --state open --json number --jq '.[].number')" ]]; then
+          if [[ $(gh pr list --label cruft | wc -c) -ne 0 ]]; then
             echo already seeing pull request
             exit 0
           fi
-          echo "template_tag=${template_tag}" >> "$GITHUB_OUTPUT"
+          template_url=$(python -c "print(__import__('json').load(open('.cruft.json'))['template'])")
+          template_ref=$(git ls-remote ${template_url} --heads main --exit-code | cut -c -6)
+          echo "template_ref=${template_ref}" >> "$GITHUB_OUTPUT"
           git checkout main
-          git checkout -b cruft/mex-template-${template_tag}
-          cruft update --checkout "${template_tag}" --skip-apply-ask
-          printf '### Changes\n\n- new template %s/releases/tag/%s\n' "$template_url" "$template_tag" > .cruft-pr-body
-          sed -i "0,/^### Changes$/{/^### Changes$/{N;s|\n|\n\n- new template ${template_url}/releases/tag/${template_tag}|}}" CHANGELOG.md
+          git checkout -b cruft/cookiecutter-template-${template_ref}
+          cruft update --skip-apply-ask
+          printf '### Changes\n\n- bumped cookiecutter template to %s/commit/%s\n' "$template_url" "$template_ref" > .cruft-pr-body
+          sed -i "0,/^### Changes/s|^### Changes.*|&\n\n- updated template to ${template_url}/commit/${template_ref}|" CHANGELOG.md
           if [[ $(find . -type f -name "*.rej" | wc -l) -ne 0 ]]; then
             printf '\n### Conflicts\n' >> .cruft-pr-body
-            echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           fi
           find . -type f -name "*.rej" | while read -r line ; do
             printf '\n```diff\n' >> .cruft-pr-body
@@ -93,31 +90,25 @@ jobs:
             printf '```\n' >> .cruft-pr-body
           done
           git add --all --verbose
-          git commit --message "Update mex-template to $template_tag" --verbose
+          git commit --message "Bump cookiecutter template to $template_ref" --verbose
 
       - name: Push branch
-        if: steps.update.outputs.template_tag
+        if: steps.update.outputs.template_ref
         env:
-          GH_TOKEN: ${{ secrets.MEX_COOKIECUTTER_TOKEN }}
-          template_tag: ${{ steps.update.outputs.template_tag }}
+          GH_TOKEN: ${{ secrets.MEX_CONTENT_WRITE_TOKEN }}
+          template_ref: ${{ steps.update.outputs.template_ref }}
         run: |
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push --set-upstream origin cruft/mex-template-${template_tag} --force --verbose
+          git push --set-upstream origin cruft/cookiecutter-template-${template_ref} --force --verbose
 
       - name: Create pull request
-        if: steps.update.outputs.template_tag
+        if: steps.update.outputs.template_ref
         env:
-          GH_TOKEN: ${{ secrets.MEX_COOKIECUTTER_TOKEN }}
-          template_tag: ${{ steps.update.outputs.template_tag }}
-          has_conflicts: ${{ steps.update.outputs.has_conflicts }}
+          GH_TOKEN: ${{ secrets.MEX_COLLAB_WRITE_TOKEN }}
+          template_ref: ${{ steps.update.outputs.template_ref }}
         run: |
-          draft_flag=""
-          if [[ "${has_conflicts}" == "true" ]]; then
-            draft_flag="--draft"
-          fi
           gh pr create \
-          --title "Bump cookiecutter template to ${template_tag}" \
+          --title "Bump cookiecutter template to ${template_ref}" \
           --body-file .cruft-pr-body \
           --label cruft \
-          --assignee ${MEX_BOT_USER} \
-          ${draft_flag}
+          --assignee ${MEX_BOT_USER}

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -52,15 +52,20 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Setup python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.14
 
       - name: Install requirements
         run: make setup
 
+      - name: Export dependencies
+        run: |
+          mkdir --parents uv
+          uv export --no-hashes --format requirements-txt --output-file uv/requirements.txt
+
       - name: Run trivy
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           format: 'sarif'
           list-all-pkgs: 'true'
@@ -70,7 +75,7 @@ jobs:
           severity: 'MEDIUM,HIGH,CRITICAL'
 
       - name: Publish results
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -59,7 +59,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Setup python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.14
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Setup python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.14
 
@@ -108,7 +108,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Setup python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.14
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -59,7 +59,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Setup python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.14
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ downloads/
 eggs/
 lib/
 lib64/
+locked-requirements.txt
 MANIFEST
 parts/
 sdist/
@@ -111,25 +112,8 @@ dmypy.json
 
 # VisualStudioCode
 .vscode/*
-!.vscode/extensions.json
-!.vscode/launch.json
-!.vscode/settings.json
-!.vscode/tasks.json
 .history/
 *.code-workspace
-
-# Node and Angular
-.angular/
-.nodeenv
-.sass-cache/
-connect.lock
-coverage
-libpeerconnection.log
-node_modules
-npm-debug.log
-out-tsc
-testem.log
-typings
 
 # SQLite databases
 *.db

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,13 @@
 fail_fast: false
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.19
+    rev: v0.15.4
     hooks:
       - id: ruff-check
-        name: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
-        name: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: v5.0.0
     hooks:
       - id: pretty-format-json
         name: json
@@ -25,7 +23,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.24
+    rev: 0.10.7
     hooks:
       - id: uv-lock
         name: uv
@@ -35,7 +33,7 @@ repos:
     - id: mypy
       name: mypy
       entry: uv run dmypy run --timeout 7200 -- mex tests
-      files: ^(mex|tests)/|pyproject\.toml$
+      files: ^(mex|tests)/
       language: system
       pass_filenames: false
       types: [python]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- new template https://github.com/robert-koch-institut/mex-template/releases/tag/1.2.0
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/f970f1
 
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/26afa8

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
     "lockFileMaintenance": {
         "enabled": true,
         "schedule": [
-            "on monday"
+            "before 4am on monday"
         ]
     },
     "packageRules": [
@@ -38,40 +38,15 @@
             "pinDigests": true
         },
         {
-            "description": "Group all GitHub Actions updates into a single PR",
-            "groupName": "github-actions",
-            "matchManagers": [
-                "github-actions"
-            ]
-        },
-        {
-            "description": "Group all non-major Python updates into a single PR",
-            "groupName": "python non-major",
-            "matchCurrentVersion": "!/^0/",
-            "matchManagers": [
-                "pep621",
-                "pip_requirements"
-            ],
-            "matchUpdateTypes": [
-                "minor",
-                "patch",
-                "pin",
-                "digest"
-            ]
-        },
-        {
-            "description": "Immediately apply updates of mex packages in dedicated PR",
-            "groupName": null,
+            "description": "Immediately apply updates of mex packages",
             "matchPackageNames": [
                 "mex-*"
             ],
             "minimumReleaseAge": "0 days"
         }
     ],
+    "platformCommit": "enabled",
     "prFooter": "",
-    "pre-commit": {
-        "enabled": true
-    },
     "vulnerabilityAlerts": {
         "enabled": true
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
-mex-release==1.3.3
-uv==0.11.24
-pre-commit==4.6.0
+mex-release==1.3.0
+uv==0.10.12
+pre-commit==4.5.1


### PR DESCRIPTION
### Changes

- new template https://github.com/robert-koch-institut/mex-template/releases/tag/1.2.0

### Conflicts

```diff
diff a/README.md b/README.md	(rejected hunks)
@@ -6,7 +6,7 @@ Release tools for the RKI MEx project.
 [![cve-scan](https://github.com/robert-koch-institut/mex-release/actions/workflows/cve-scan.yml/badge.svg)](https://github.com/robert-koch-institut/mex-release/actions/workflows/cve-scan.yml)
 [![documentation](https://github.com/robert-koch-institut/mex-release/actions/workflows/documentation.yml/badge.svg)](https://robert-koch-institut.github.io/mex-release)
 [![linting](https://github.com/robert-koch-institut/mex-release/actions/workflows/linting.yml/badge.svg)](https://github.com/robert-koch-institut/mex-release/actions/workflows/linting.yml)
-[![opencode](https://github.com/robert-koch-institut/mex-release/actions/workflows/opencode.yml/badge.svg)](https://gitlab.opencode.de/robert-koch-institut/mex/mex-release)
+[![open-code](https://github.com/robert-koch-institut/mex-release/actions/workflows/open-code.yml/badge.svg)](https://gitlab.opencode.de/robert-koch-institut/mex/mex-release)
 [![testing](https://github.com/robert-koch-institut/mex-release/actions/workflows/testing.yml/badge.svg)](https://github.com/robert-koch-institut/mex-release/actions/workflows/testing.yml)
 
 ## Project
@@ -89,13 +89,6 @@ components of the MEx project are open-sourced under the same license as well.
 - run directly using docker `make run`
 - start with docker compose `make start`
 
-### Container verification
-
-Images released to GHCR are signed using [cosign](https://github.com/sigstore/cosign).
-
-To verify an image manually:
-`cosign verify --certificate-identity-regexp "https://github.com/robert-koch-institut/mex-release/.github/workflows/release.yml@refs/heads/main" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ghcr.io/robert-koch-institut/mex-release:<tag>`
-
 ## Commands
 
 - run `uv run {command} --help` to print instructions
```

```diff
diff a/Makefile b/Makefile	(rejected hunks)
@@ -43,6 +43,7 @@ wheel:
 image:
 	# build the docker image
 	@ echo building docker image mex-release:${LATEST}; \
+	export DOCKER_BUILDKIT=1; \
 	docker build \
 		--tag rki/mex-release:${LATEST} \
 		--tag rki/mex-release:latest .; \
@@ -52,13 +53,15 @@ run: image
 	@ echo running docker container mex-release:${LATEST}; \
 	docker run \
 		--env MEX_RELEASE_HOST=0.0.0.0 \
-		--publish 8080:8080 \
+		--publish 8081:8081 \
 		rki/mex-release:${LATEST}; \
 
-start:
+start: image
 	# start the service using docker compose
 	@ echo start mex-release:${LATEST} with compose; \
-	docker compose up --build --remove-orphans; \
+	export DOCKER_BUILDKIT=1; \
+	export COMPOSE_DOCKER_CLI_BUILD=1; \
+	docker compose up --remove-orphans; \
 
 docs:
 	# use sphinx to auto-generate html docs from code
```

```diff
diff a/pyproject.toml b/pyproject.toml	(rejected hunks)
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Release tools for the RKI MEx project."
 authors = [{ name = "MEx Team", email = "mex@rki.de" }]
 readme = { file = "README.md", content-type = "text/markdown" }
-license = "MIT"
+license = { file = "LICENSE" }
 urls = { Repository = "https://github.com/robert-koch-institut/mex-release" }
 requires-python = ">=3.14,<3.15"
 dependencies = [
```

```diff
diff a/.github/workflows/opencode.yml b/.github/workflows/opencode.yml	(rejected hunks)
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: 'main'
           fetch-depth: 0
```

```diff
diff a/.github/workflows/linting.yml b/.github/workflows/linting.yml	(rejected hunks)
@@ -34,12 +34,12 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
@@ -49,7 +49,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Cache environment
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-environment
         with:
```

```diff
diff a/.github/workflows/release.yml b/.github/workflows/release.yml	(rejected hunks)
@@ -38,13 +38,13 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: Cache requirements
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
@@ -85,48 +85,54 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write  # Required for cosign signing
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           ref: ${{ needs.release.outputs.tag }}
           persist-credentials: false
 
+      - name: Cache requirements
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        env:
+          cache-name: cache-requirements
+        with:
+          path: ~/.cache/pip
+          key: ${{ env.cache-name }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ env.cache-name }}-
+
+      - name: Setup python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: 3.14
+
+      - name: Install requirements
+        run: make setup
+
+      - name: Generate locked requirements.txt
+        run: |
+          uv export --no-dev --output locked-requirements.txt --no-hashes
+
       - name: Login to container registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
 
       - name: Build, tag and push docker image
-        id: push_step
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v.7.1.0
         env:
           IMAGE: ghcr.io/${{ github.repository }}
           TAG: ${{ needs.release.outputs.tag }}
-        with:
-          context: .
-          push: true
-          tags: |
-            ${{ env.IMAGE }}:latest
-            ${{ env.IMAGE }}:${{ github.sha }}
-            ${{ env.IMAGE }}:${{ env.TAG }}
-          outputs: type=image,oci-mediatypes=true
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        with:
-          cosign-release: 'v2.4.1'
-
-      - name: Sign Docker image keyless
-        env:
-          IMAGE: ghcr.io/${{ github.repository }}@${{ steps.push_step.outputs.digest }}
         run: |
-          cosign sign --yes "$IMAGE"
+          docker build . \
+          --tag ${IMAGE}:latest \
+          --tag ${IMAGE}:${{ github.sha }} \
+          --tag ${IMAGE}:${TAG}
+          docker push --all-tags ${IMAGE}
 
   distribute:
     runs-on: ubuntu-latest
@@ -137,14 +143,14 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           ref: ${{ needs.release.outputs.tag }}
           persist-credentials: false
 
       - name: Cache requirements
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
@@ -165,6 +171,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          uv build --out-dir dist
           gh release create ${{ needs.release.outputs.tag }} \
-          --generate-notes --latest --verify-tag dist/*
+          --generate-notes --latest --verify-tag
+          uv build --out-dir dist
+          for filename in dist/*; do
+            gh release upload ${{ needs.release.outputs.tag }} ${filename};
+          done
```

```diff
diff a/.github/workflows/cve-scan.yml b/.github/workflows/cve-scan.yml	(rejected hunks)
@@ -27,12 +27,12 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
@@ -42,7 +42,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Cache environment
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-environment
         with:
```

```diff
diff a/.github/workflows/cookiecutter.yml b/.github/workflows/cookiecutter.yml	(rejected hunks)
@@ -31,13 +31,13 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Cache requirements
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
```

```diff
diff a/.github/workflows/renovatebot.yml b/.github/workflows/renovatebot.yml	(rejected hunks)
@@ -20,14 +20,13 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@6d859fc95779be83a0335ca704879b47e5d79641 # v46.1.16
+        uses: renovatebot/github-action@68a3ea99af6ad249940b5a9fdf44fc6d7f14378b # v46.1.6
         env:
-          RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.MEX_PLAIN_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
         with:
           configurationFile: renovate.json
```

```diff
diff a/.github/workflows/reviewing.yml b/.github/workflows/reviewing.yml	(rejected hunks)
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
```

```diff
diff a/.github/workflows/testing.yml b/.github/workflows/testing.yml	(rejected hunks)
@@ -34,12 +34,12 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-requirements
         with:
@@ -49,7 +49,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Cache environment
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-environment
         with:
```
