### PR TITLE
feature/mx-2191-lock-no-refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/f970f1
-
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/26afa8
-
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/57105a
-
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/dd987e
 
 ### Deprecated
@@ -24,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+- stop refreshing packages as part of release process, only lock new version of repo
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- switch to annotated tags so we can push tag and commit atomically
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/f970f1
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/26afa8
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/57105a

--- a/mex/release/release.py
+++ b/mex/release/release.py
@@ -176,8 +176,8 @@ class Releaser:
             "pyproject.toml",
             "uv.lock",
         )
-        self.run("git", "tag", f"{new_version}")
-        self.run("git", "git", "push", "--atomic", "--follow-tags")
+        self.run("git", "tag", "-a", f"{new_version}", "-m", f"{new_version}")
+        self.run("git", "push", "--atomic", "--follow-tags")
 
         typer.secho(
             f"Successfully released version {new_version}!",

--- a/mex/release/release.py
+++ b/mex/release/release.py
@@ -132,8 +132,20 @@ class Releaser:
         with Path.open(self.pyproject_path, "w", encoding="utf-8") as f:
             tomlkit.dump(self.pyproject_data, f)
 
-        self.run("uv", "lock", "--refresh")
+        # write pyproject version to lock file
+        self.run("uv", "lock")
         typer.secho("Lock file updated at [success]uv.lock[/].", fg=typer.colors.GREEN)
+
+        # verify pyproject and lock file
+        actual_diff = self.run("git", "diff", "--unified=0")
+        expected_diff = (
+            rf'-version = "{re.escape(current_version)}"\n'
+            rf'\+version = "{re.escape(new_version)}"'
+        )
+        expected_version_changes = 2  # pyproject.toml + uv.lock
+        if len(re.findall(expected_diff, actual_diff)) != expected_version_changes:
+            typer.secho(f"Unexpected changeset:\n{actual_diff}", fg=typer.colors.RED)
+            raise typer.Exit(code=1)
 
         # rollover changelog sections
         with Path.open(self.changelog_path, "r", encoding="utf-8") as fh:
@@ -165,8 +177,7 @@ class Releaser:
             "uv.lock",
         )
         self.run("git", "tag", f"{new_version}")
-        self.run("git", "push")
-        self.run("git", "push", "--tags")
+        self.run("git", "git", "push", "--atomic", "--follow-tags")
 
         typer.secho(
             f"Successfully released version {new_version}!",

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -72,6 +72,9 @@ def test_releaser_release(context: Context, capsys: CaptureFixture[str]) -> None
 
     def _fake_run(*args: str) -> str:
         calls.append(args)
+        if args[:2] == ("git", "diff"):
+            # pyproject.toml + uv.lock both bump 1.2.3 -> 1.2.4
+            return '-version = "1.2.3"\n+version = "1.2.4"\n' * 2
         return ""
 
     calls: list[tuple[str, ...]] = []
@@ -88,7 +91,14 @@ def test_releaser_release(context: Context, capsys: CaptureFixture[str]) -> None
 
     # test valid version
     releaser_major = Releaser(context.obj["root"], "major")
-    releaser_major.run = MagicMock(return_value="")  # type: ignore[method-assign]
+
+    def _fake_run_major(*args: str) -> str:
+        if args[:2] == ("git", "diff"):
+            # pyproject.toml + uv.lock both bump 1.2.4 -> 2.0.0
+            return '-version = "1.2.4"\n+version = "2.0.0"\n' * 2
+        return ""
+
+    releaser_major.run = MagicMock(side_effect=_fake_run_major)  # type: ignore[method-assign]
     releaser_major.check_working_tree = MagicMock()  # type: ignore[method-assign]
     releaser_major.check_default_branch = MagicMock()  # type: ignore[method-assign]
     releaser_major.release()
@@ -102,6 +112,19 @@ def test_releaser_release(context: Context, capsys: CaptureFixture[str]) -> None
     with pytest.raises(Exit):
         releaser_bad.release()
     assert "Unexpected bump value" in capsys.readouterr().out
+
+
+def test_releaser_release_unexpected_changeset(
+    context: Context, capsys: CaptureFixture[str]
+) -> None:
+    releaser = Releaser(context.obj["root"], "patch")
+    # git diff returns an empty changeset, so the expected version bump is missing
+    releaser.run = MagicMock(return_value="")  # type: ignore[method-assign]
+    releaser.check_working_tree = MagicMock()  # type: ignore[method-assign]
+    releaser.check_default_branch = MagicMock()  # type: ignore[method-assign]
+    with pytest.raises(Exit):
+        releaser.release()
+    assert "Unexpected changeset" in capsys.readouterr().out
 
 
 def test_release(context: Context, capsys: CaptureFixture[str]) -> None:


### PR DESCRIPTION
### Changed

- switch to annotated tags so we can push tag and commit atomically (to avoid race conditions)

### Fixed

- stop refreshing packages as part of release process, only lock new version of repo
