### PR TITLE
Bump cookiecutter template to 1.3.0

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,14 +1,14 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "f970f135d97da17b564067eeb9630a691d094b6b",
-  "checkout": null,
+  "commit": "192830effd8041fcff795b110a3915093c96c00e",
+  "checkout": "1.3.0",
   "context": {
     "cookiecutter": {
       "project_name": "release",
       "short_summary": "Release tools for the RKI MEx project.",
       "long_summary": "Create a new release, including changelog rollover, project version bump, commit, tag and push.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "f970f135d97da17b564067eeb9630a691d094b6b"
+      "_commit": "192830effd8041fcff795b110a3915093c96c00e"
     }
   },
   "directory": null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- new template https://github.com/robert-koch-institut/mex-template/releases/tag/1.3.0
 - switch to annotated tags so we can push tag and commit atomically
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/f970f1
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/26afa8


### PR DESCRIPTION
### Changes

- new template https://github.com/robert-koch-institut/mex-template/releases/tag/1.3.0
