### PR TITLE
Bump cookiecutter template to 1.4.0

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,14 +1,14 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "192830effd8041fcff795b110a3915093c96c00e",
-  "checkout": "1.3.0",
+  "commit": "c6d13eb329f5a884e4ea9cbdcdb12c3299b9c11c",
+  "checkout": "1.4.0",
   "context": {
     "cookiecutter": {
       "project_name": "release",
       "short_summary": "Release tools for the RKI MEx project.",
       "long_summary": "Create a new release, including changelog rollover, project version bump, commit, tag and push.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "192830effd8041fcff795b110a3915093c96c00e"
+      "_commit": "c6d13eb329f5a884e4ea9cbdcdb12c3299b9c11c"
     }
   },
   "directory": null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- new template https://github.com/robert-koch-institut/mex-template/releases/tag/1.4.0
 ### Deprecated
 
 ### Removed

--- a/renovate.json
+++ b/renovate.json
@@ -31,8 +31,9 @@
             "minimumReleaseAgeBehaviour": "timestamp-optional"
         },
         {
-            "description": "Pin GitHub Actions to SHA digests for supply chain security",
+            "description": "Pin GitHub Actions and compose images to SHA digests for supply chain security",
             "matchManagers": [
+                "docker-compose",
                 "github-actions"
             ],
             "pinDigests": true


### PR DESCRIPTION
### Changes

- new template https://github.com/robert-koch-institut/mex-template/releases/tag/1.4.0
